### PR TITLE
Clarify authentication protocol vs scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Rust crate to handle authentication of HTTP calls.  Documentation at https://docs.rs/authentic/latest/authentic/.
 
-Authentication schemes can require specific workflows, such as making third-party calls to refresh a token or performing an initial request to get challenge information.
+Authentication protocols can require specific workflows, such as making third-party calls to refresh a token or performing an initial request to get challenge information.
 
-Using a fixed code structure, `authentic` can perform the necessary interactions for each authentication scheme. This allows schemes to be changed easily.
+Using a fixed code structure, `authentic` can perform the necessary interactions for each authentication protocol. This allows protocols to be changed easily.
 
 For example, the following code uses `reqwest` to access a site using HTTP Basic authentication. (See the [repository tests directory](https://github.com/jinxapi/authentic/tree/main/tests) for fully working examples).
 
@@ -47,15 +47,15 @@ let response = loop {
 };
 ```
 
-The creation of the request takes place inside a loop. First, the authentication scheme is given an opportunity to perform any third-party calls using `step()`.
+The creation of the request takes place inside a loop. First, the authentication protocol is given an opportunity to perform any third-party calls using `step()`.
 HTTP Basic authentication does not use this, but it can be used, for example, to refresh an expired OAuth2 access token.
 
-The request is created using a standard `reqwest::RequestBuilder`, using a new `with_authentication()` method to modify the request for the authentication scheme.
+The request is created using a standard `reqwest::RequestBuilder`, using a new `with_authentication()` method to modify the request for the authentication protocol.
 For HTTP authentication, the first iteration makes no change to the request.
 
 The request is sent and a response is received.  For HTTP authentication, this returns a `401 Unauthorized` response.
 
-The `has_completed()` method checks if the response is ready to be returned or if the authentication scheme needs to retry.
+The `has_completed()` method checks if the response is ready to be returned or if the authentication protocol needs to retry.
 For HTTP authentication, this reads the returned `www-authenticate` challenge and establishes the correct credentials.
 As the request needs to be retried, `has_completed()` returns `false` and a second iteration begins.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! Handle authentication of HTTP calls.
 //!
-//! Authentication schemes can require specific workflows, such as making third-party calls to refresh a token or performing an initial request to get challenge information.
+//! Authentication protocols can require specific workflows, such as making third-party calls to refresh a token or performing an initial request to get challenge information.
 //!
-//! Using a fixed code structure, `authentic` can perform the necessary interactions for each authentication scheme. This allows schemes to be changed easily.
+//! Using a fixed code structure, `authentic` can perform the necessary interactions for each authentication protocol. This allows protocols to be changed easily.
 //!
 //! For example, the following code uses `reqwest` to access a site using HTTP Basic authentication. (See the [repository tests directory](https://github.com/jinxapi/authentic/tree/main/tests) for fully working examples).
 //!
@@ -47,15 +47,15 @@
 //! };
 //! ```
 //!
-//! The creation of the request takes place inside a loop. First, the authentication scheme is given an opportunity to perform any third-party calls using `step()`.
+//! The creation of the request takes place inside a loop. First, the authentication protocol is given an opportunity to perform any third-party calls using `step()`.
 //! HTTP Basic authentication does not use this, but it can be used, for example, to refresh an expired OAuth2 access token.
 //!
-//! The request is created using a standard `reqwest` RequestBuilder, using a new `with_authentication()` method to modify the request for the authentication scheme.
+//! The request is created using a standard `reqwest` RequestBuilder, using a new `with_authentication()` method to modify the request for the authentication protocol.
 //! For HTTP authentication, the first iteration makes no change to the request.
 //!
 //! The request is sent and a response is received.  For HTTP authentication, this returns a `401 Unauthorized` response.
 //!
-//! The `has_completed()` method checks if the response is ready to be returned or if the authentication scheme needs to retry.
+//! The `has_completed()` method checks if the response is ready to be returned or if the authentication protocol needs to retry.
 //! For HTTP authentication, this reads the returned `www-authenticate` challenge and establishes the correct credentials.
 //! As the request needs to be retried, `has_completed()` returns `false` and a second iteration begins.
 //!
@@ -108,7 +108,7 @@ pub trait AuthenticationProcess {
     }
 }
 
-pub trait AuthenticationScheme {
+pub trait AuthenticationProtocol {
     type Builder;
     type Request;
     type Response;
@@ -145,14 +145,14 @@ where
     #[must_use]
     fn with_authentication(
         self,
-        scheme: &dyn AuthenticationScheme<
+        protocol: &dyn AuthenticationProtocol<
             Builder = Self,
             Request = Request,
             Response = Response,
             Error = Error,
         >,
     ) -> Self {
-        scheme.configure(self)
+        protocol.configure(self)
     }
 }
 

--- a/src/reqwest/blocking.rs
+++ b/src/reqwest/blocking.rs
@@ -1,4 +1,4 @@
-//! Authentication schemes for use with blocking `reqwest`.
+//! Authentication protocols for use with blocking `reqwest`.
 //! Use the `reqwest_blocking` feature to enable these.
 
 use std::borrow::Cow;
@@ -8,11 +8,11 @@ use crate::credential::{
     AuthenticationCredentialToken, AuthenticationCredentialUsernamePassword, HttpRealmCredentials,
 };
 use crate::sensitive::SetSensitiveHeader;
-use crate::{AuthenticError, AuthenticationScheme, AuthenticationStep};
+use crate::{AuthenticError, AuthenticationProtocol, AuthenticationStep};
 
-/// No authentication scheme
+/// Protocol for no authentication
 ///
-/// Identical to not using `authentic` but allows minimal code changes when changing schemes.
+/// Identical to not using `authentic` but allows minimal code changes when changing protocols.
 pub struct NoAuthentication;
 
 impl NoAuthentication {
@@ -22,7 +22,7 @@ impl NoAuthentication {
     }
 }
 
-impl AuthenticationScheme for NoAuthentication {
+impl AuthenticationProtocol for NoAuthentication {
     type Builder = reqwest::blocking::RequestBuilder;
     type Request = reqwest::blocking::Request;
     type Response = reqwest::blocking::Response;
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<Credential> AuthenticationScheme for HeaderAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for HeaderAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
@@ -63,7 +63,7 @@ where
 
 /// Authentication using a bearer token in the HTTP Authorization header.
 pub struct BearerAuthentication<Credential> {
-    scheme_name: Cow<'static, str>,
+    auth_scheme: Cow<'static, str>,
     credential: Arc<Credential>,
 }
 
@@ -73,7 +73,7 @@ where
 {
     pub fn new(credential: &Arc<Credential>) -> Self {
         Self {
-            scheme_name: "Bearer".into(),
+            auth_scheme: "Bearer".into(),
             credential: credential.clone(),
         }
     }
@@ -82,13 +82,13 @@ where
     ///
     /// Some systems use a bearer token, but use a scheme name other
     /// than `Bearer`.
-    pub fn with_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.scheme_name = name.into();
+    pub fn with_auth_scheme(mut self, auth_scheme: impl Into<Cow<'static, str>>) -> Self {
+        self.auth_scheme = auth_scheme.into();
         self
     }
 }
 
-impl<Credential> AuthenticationScheme for BearerAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for BearerAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
@@ -99,8 +99,8 @@ where
 
     fn configure(&self, builder: Self::Builder) -> Self::Builder {
         let token = self.credential.token();
-        let mut value = Vec::with_capacity(self.scheme_name.len() + 1 + token.len());
-        value.extend(self.scheme_name.as_bytes());
+        let mut value = Vec::with_capacity(self.auth_scheme.len() + 1 + token.len());
+        value.extend(self.auth_scheme.as_bytes());
         value.push(b' ');
         value.extend(token);
         builder.set_sensitive_header(hyper::header::AUTHORIZATION, &value[..])
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<Credential> AuthenticationScheme for BasicAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for BasicAuthentication<Credential>
 where
     Credential: AuthenticationCredentialUsernamePassword,
 {
@@ -153,7 +153,7 @@ impl<Credential> HttpAuthentication<Credential> {
     }
 }
 
-impl<Credential> AuthenticationScheme for HttpAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for HttpAuthentication<Credential>
 where
     Credential: AuthenticationCredentialUsernamePassword + 'static,
 {

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,4 +1,4 @@
-//! Authentication schemes for use with `reqwest`.
+//! Authentication protocols for use with `reqwest`.
 //! Use the `reqwest_async` feature to enable these.
 
 use std::borrow::Cow;
@@ -8,14 +8,14 @@ use crate::credential::{
     AuthenticationCredentialToken, AuthenticationCredentialUsernamePassword, HttpRealmCredentials,
 };
 use crate::sensitive::SetSensitiveHeader;
-use crate::{AuthenticError, AuthenticationScheme, AuthenticationStep};
+use crate::{AuthenticError, AuthenticationProtocol, AuthenticationStep};
 
 #[cfg(feature = "reqwest_blocking")]
 pub mod blocking;
 
-/// No authentication scheme
+/// Protocol for no authentication
 ///
-/// Identical to not using `authentic` but allows minimal code changes when changing schemes.
+/// Identical to not using `authentic` but allows minimal code changes when changing protocols.
 pub struct NoAuthentication;
 
 impl NoAuthentication {
@@ -25,7 +25,7 @@ impl NoAuthentication {
     }
 }
 
-impl AuthenticationScheme for NoAuthentication {
+impl AuthenticationProtocol for NoAuthentication {
     type Builder = reqwest::RequestBuilder;
     type Request = reqwest::Request;
     type Response = reqwest::Response;
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<Credential> AuthenticationScheme for HeaderAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for HeaderAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
@@ -66,7 +66,7 @@ where
 
 /// Authentication using a bearer token in the HTTP Authorization header.
 pub struct BearerAuthentication<Credential> {
-    scheme_name: Cow<'static, str>,
+    auth_scheme: Cow<'static, str>,
     credential: Arc<Credential>,
 }
 
@@ -76,7 +76,7 @@ where
 {
     pub fn new(credential: &Arc<Credential>) -> Self {
         Self {
-            scheme_name: "Bearer".into(),
+            auth_scheme: "Bearer".into(),
             credential: credential.clone(),
         }
     }
@@ -85,13 +85,13 @@ where
     ///
     /// Some systems use a bearer token, but use a scheme name other
     /// than `Bearer`.
-    pub fn with_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.scheme_name = name.into();
+    pub fn with_auth_scheme(mut self, auth_scheme: impl Into<Cow<'static, str>>) -> Self {
+        self.auth_scheme = auth_scheme.into();
         self
     }
 }
 
-impl<Credential> AuthenticationScheme for BearerAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for BearerAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
@@ -102,8 +102,8 @@ where
 
     fn configure(&self, builder: Self::Builder) -> Self::Builder {
         let token = self.credential.token();
-        let mut value = Vec::with_capacity(self.scheme_name.len() + 1 + token.len());
-        value.extend(self.scheme_name.as_bytes());
+        let mut value = Vec::with_capacity(self.auth_scheme.len() + 1 + token.len());
+        value.extend(self.auth_scheme.as_bytes());
         value.push(b' ');
         value.extend(token);
         builder.set_sensitive_header(hyper::header::AUTHORIZATION, &value[..])
@@ -126,7 +126,7 @@ where
     }
 }
 
-impl<Credential> AuthenticationScheme for BasicAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for BasicAuthentication<Credential>
 where
     Credential: AuthenticationCredentialUsernamePassword,
 {
@@ -156,7 +156,7 @@ impl<Credential> HttpAuthentication<Credential> {
     }
 }
 
-impl<Credential> AuthenticationScheme for HttpAuthentication<Credential>
+impl<Credential> AuthenticationProtocol for HttpAuthentication<Credential>
 where
     Credential: AuthenticationCredentialUsernamePassword + 'static,
 {

--- a/tests/hyper_basic.rs
+++ b/tests/hyper_basic.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use authentic::credential::{HttpRealmCredentials, UsernamePasswordCredential};
 use authentic::hyper::{BasicAuthentication, HttpAuthentication};
-use authentic::{AuthenticationScheme, AuthenticationStep, WithAuthentication};
+use authentic::{AuthenticationProtocol, AuthenticationStep, WithAuthentication};
 use http::StatusCode;
 use hyper::Client;
 use hyper_tls::HttpsConnector;

--- a/tests/reqwest_async_basic.rs
+++ b/tests/reqwest_async_basic.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use ::reqwest::Client;
 use authentic::credential::{HttpRealmCredentials, UsernamePasswordCredential};
 use authentic::reqwest::{BasicAuthentication, HttpAuthentication};
-use authentic::{AuthenticationScheme, AuthenticationStep, WithAuthentication};
+use authentic::{AuthenticationProtocol, AuthenticationStep, WithAuthentication};
 use http::StatusCode;
 
 /// Direct basic authentication, passing the username and password on the first request.

--- a/tests/reqwest_blocking_basic.rs
+++ b/tests/reqwest_blocking_basic.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use ::reqwest::blocking::Client;
 use authentic::credential::{HttpRealmCredentials, UsernamePasswordCredential};
 use authentic::reqwest::blocking::{BasicAuthentication, HttpAuthentication};
-use authentic::{AuthenticationScheme, AuthenticationStep, WithAuthentication};
+use authentic::{AuthenticationProtocol, AuthenticationStep, WithAuthentication};
 use http::StatusCode;
 
 /// Direct basic authentication, passing the username and password on the first request.


### PR DESCRIPTION
Use "authentication scheme" for the label in a HTTP authorization
header, to match RFC terminology.

Use "authentication protocol" for the trait that described the working
of a specific method of authentication.