### PR TITLE
Use str for header name

### DIFF
--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -31,7 +31,7 @@ impl AuthenticationScheme for NoAuthentication {
 
 /// Authentication using a token in a specified header.
 pub struct HeaderAuthentication<Credential> {
-    header_name: Cow<'static, [u8]>,
+    header_name: Cow<'static, str>,
     credential: Arc<Credential>,
 }
 
@@ -39,7 +39,7 @@ impl<Credential: 'static> HeaderAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
-    pub fn new(header_name: Cow<'static, [u8]>, credential: &Arc<Credential>) -> Self {
+    pub fn new(header_name: Cow<'static, str>, credential: &Arc<Credential>) -> Self {
         Self {
             header_name,
             credential: credential.clone(),

--- a/src/reqwest/blocking.rs
+++ b/src/reqwest/blocking.rs
@@ -31,7 +31,7 @@ impl AuthenticationScheme for NoAuthentication {
 
 /// Authentication using a token in a specified header.
 pub struct HeaderAuthentication<Credential> {
-    header_name: Cow<'static, [u8]>,
+    header_name: Cow<'static, str>,
     credential: Arc<Credential>,
 }
 
@@ -39,7 +39,7 @@ impl<Credential: 'static> HeaderAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
-    pub fn new(header_name: Cow<'static, [u8]>, credential: &Arc<Credential>) -> Self {
+    pub fn new(header_name: Cow<'static, str>, credential: &Arc<Credential>) -> Self {
         Self {
             header_name,
             credential: credential.clone(),

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -34,7 +34,7 @@ impl AuthenticationScheme for NoAuthentication {
 
 /// Authentication using a token in a specified header.
 pub struct HeaderAuthentication<Credential> {
-    header_name: Cow<'static, [u8]>,
+    header_name: Cow<'static, str>,
     credential: Arc<Credential>,
 }
 
@@ -42,7 +42,7 @@ impl<Credential: 'static> HeaderAuthentication<Credential>
 where
     Credential: AuthenticationCredentialToken,
 {
-    pub fn new(header_name: Cow<'static, [u8]>, credential: &Arc<Credential>) -> Self {
+    pub fn new(header_name: Cow<'static, str>, credential: &Arc<Credential>) -> Self {
         Self {
             header_name,
             credential: credential.clone(),


### PR DESCRIPTION
Header names are ASCII tokens.  Use `str` to represent them.