### PR TITLE
Support both reqwest's Request and RequestBuilder

### DIFF
--- a/tests/hyper_basic.rs
+++ b/tests/hyper_basic.rs
@@ -17,16 +17,16 @@ async fn test_basic_authentication(
     let client = Client::builder().build::<_, ::hyper::Body>(https);
 
     let credential = UsernamePasswordCredential::new("username", "password");
-    let mut scheme = BasicAuthentication::new(&credential);
+    let mut authentication = BasicAuthentication::new(&credential);
 
     let mut status_codes = Vec::new();
 
     let _response = loop {
-        while let Some(auth_step) = scheme.step() {
+        while let Some(auth_step) = authentication.step() {
             match auth_step {
                 AuthenticationStep::Request(request) => {
                     let auth_response = client.request(request).await;
-                    scheme.respond(auth_response);
+                    authentication.respond(auth_response);
                 }
                 AuthenticationStep::WaitFor(duration) => {
                     ::tokio::time::sleep(duration).await;
@@ -34,7 +34,7 @@ async fn test_basic_authentication(
             }
         }
         let request = ::hyper::Request::get("https://httpbin.org/basic-auth/username/password")
-            .with_authentication(&scheme)?
+            .with_authentication(&authentication)?
             .body(::hyper::Body::empty())?;
 
         dbg!(&request);
@@ -45,7 +45,7 @@ async fn test_basic_authentication(
 
         status_codes.push(response.status());
 
-        if scheme.has_completed(&response)? {
+        if authentication.has_completed(&response)? {
             break response;
         }
     };
@@ -67,16 +67,16 @@ async fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error + Send +
         UsernamePasswordCredential::new("username", "password"),
     );
     let credential = HttpRealmCredentials::new(realm_credentials);
-    let mut scheme = HttpAuthentication::new(&credential);
+    let mut authentication = HttpAuthentication::new(&credential);
 
     let mut status_codes = Vec::new();
 
     let _response = loop {
-        while let Some(auth_step) = scheme.step() {
+        while let Some(auth_step) = authentication.step() {
             match auth_step {
                 AuthenticationStep::Request(request) => {
                     let auth_response = client.request(request).await;
-                    scheme.respond(auth_response);
+                    authentication.respond(auth_response);
                 }
                 AuthenticationStep::WaitFor(duration) => {
                     ::tokio::time::sleep(duration).await;
@@ -84,7 +84,7 @@ async fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error + Send +
             }
         }
         let request = ::hyper::Request::get("https://httpbin.org/basic-auth/username/password")
-            .with_authentication(&scheme)?
+            .with_authentication(&authentication)?
             .body(::hyper::Body::empty())?;
 
         dbg!(&request);
@@ -95,7 +95,7 @@ async fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error + Send +
 
         status_codes.push(response.status());
 
-        if scheme.has_completed(&response)? {
+        if authentication.has_completed(&response)? {
             break response;
         }
     };

--- a/tests/reqwest_blocking_basic.rs
+++ b/tests/reqwest_blocking_basic.rs
@@ -9,21 +9,64 @@ use authentic::{AuthenticationProtocol, AuthenticationStep, WithAuthentication};
 use http::StatusCode;
 
 /// Direct basic authentication, passing the username and password on the first request.
+/// In this test, the authentication is added to the RequestBuilder.
 #[test]
-fn test_basic_authentication() -> Result<(), Box<dyn std::error::Error>> {
+fn test_basic_builder() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
 
     let credential = UsernamePasswordCredential::new("username", "password");
-    let mut scheme = BasicAuthentication::new(&credential);
+    let mut authentication = BasicAuthentication::new(&credential);
 
     let mut status_codes = Vec::new();
 
     let _response = loop {
-        while let Some(auth_step) = scheme.step() {
+        while let Some(auth_step) = authentication.step() {
             match auth_step {
                 AuthenticationStep::Request(request) => {
                     let auth_response = client.execute(request);
-                    scheme.respond(auth_response);
+                    authentication.respond(auth_response);
+                }
+                AuthenticationStep::WaitFor(duration) => {
+                    std::thread::sleep(duration);
+                }
+            }
+        }
+        let response = client
+            .get("https://httpbin.org/basic-auth/username/password")
+            .with_authentication(&authentication)?
+            .send()?;
+
+        dbg!(&response);
+
+        status_codes.push(response.status());
+
+        if authentication.has_completed(&response)? {
+            break response;
+        }
+    };
+
+    assert_eq!(status_codes, [StatusCode::OK]);
+
+    Ok(())
+}
+
+/// Direct basic authentication, passing the username and password on the first request.
+/// In this test, the authentication is added to the Request.
+#[test]
+fn test_basic_request() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+
+    let credential = UsernamePasswordCredential::new("username", "password");
+    let mut authentication = BasicAuthentication::new(&credential);
+
+    let mut status_codes = Vec::new();
+
+    let _response = loop {
+        while let Some(auth_step) = authentication.step() {
+            match auth_step {
+                AuthenticationStep::Request(request) => {
+                    let auth_response = client.execute(request);
+                    authentication.respond(auth_response);
                 }
                 AuthenticationStep::WaitFor(duration) => {
                     std::thread::sleep(duration);
@@ -33,7 +76,7 @@ fn test_basic_authentication() -> Result<(), Box<dyn std::error::Error>> {
         let request = client
             .get("https://httpbin.org/basic-auth/username/password")
             .build()?
-            .with_authentication(&scheme)?;
+            .with_authentication(&authentication)?;
 
         dbg!(&request);
 
@@ -43,7 +86,7 @@ fn test_basic_authentication() -> Result<(), Box<dyn std::error::Error>> {
 
         status_codes.push(response.status());
 
-        if scheme.has_completed(&response)? {
+        if authentication.has_completed(&response)? {
             break response;
         }
     };
@@ -64,16 +107,16 @@ fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error>> {
         UsernamePasswordCredential::new("username", "password"),
     );
     let credential = HttpRealmCredentials::new(realm_credentials);
-    let mut scheme = HttpAuthentication::new(&credential);
+    let mut authentication = HttpAuthentication::new(&credential);
 
     let mut status_codes = Vec::new();
 
     let _response = loop {
-        while let Some(auth_step) = scheme.step() {
+        while let Some(auth_step) = authentication.step() {
             match auth_step {
                 AuthenticationStep::Request(request) => {
                     let auth_response = client.execute(request);
-                    scheme.respond(auth_response);
+                    authentication.respond(auth_response);
                 }
                 AuthenticationStep::WaitFor(duration) => {
                     std::thread::sleep(duration);
@@ -83,7 +126,7 @@ fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error>> {
         let request = client
             .get("https://httpbin.org/basic-auth/username/password")
             .build()?
-            .with_authentication(&scheme)?;
+            .with_authentication(&authentication)?;
 
         dbg!(&request);
 
@@ -93,7 +136,7 @@ fn test_basic_challenge() -> Result<(), Box<dyn std::error::Error>> {
 
         status_codes.push(response.status());
 
-        if scheme.has_completed(&response)? {
+        if authentication.has_completed(&response)? {
             break response;
         }
     };


### PR DESCRIPTION
We want to support `Request` because it can be created separately to a specific client, but we also would like to support `RequestBuilder` since the `send` command skips exposing the `Request`.

Adding a separate trait for `configure` that is generic on the "builder" type allows it to work for both types.