### PR TITLE
Use correct module for headers

### DIFF
--- a/src/reqwest/blocking.rs
+++ b/src/reqwest/blocking.rs
@@ -293,7 +293,7 @@ where
                     let pw_client = ::http_auth::PasswordClient::try_from(
                         response
                             .headers()
-                            .get_all(::hyper::header::WWW_AUTHENTICATE),
+                            .get_all(::reqwest::header::WWW_AUTHENTICATE),
                     )
                     .map_err(AuthenticError::Other)?;
                     match pw_client {

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -307,7 +307,7 @@ where
                     let pw_client = ::http_auth::PasswordClient::try_from(
                         response
                             .headers()
-                            .get_all(::hyper::header::WWW_AUTHENTICATE),
+                            .get_all(::reqwest::header::WWW_AUTHENTICATE),
                     )
                     .map_err(AuthenticError::Other)?;
                     match pw_client {


### PR DESCRIPTION
Use `reqwest::header` for `reqwest` code. This is to follow docs correctly. The previous state did not cause an error since both `hyper` and `reqwest` use `http::header` for the underlying values.